### PR TITLE
ci(core): add automatic labeling for Dependabot pull requests

### DIFF
--- a/.github/workflows/conventional-labels.yml
+++ b/.github/workflows/conventional-labels.yml
@@ -2,7 +2,7 @@ name: Conventional Labels
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, reopened, labeled, synchronize]
 
 permissions:
   pull-requests: write

--- a/.github/workflows/dependabot-labels.yml
+++ b/.github/workflows/dependabot-labels.yml
@@ -1,0 +1,28 @@
+name: Dependabot Labels
+
+on:
+  pull_request:
+    types: [opened, reopened, labeled, synchronize]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  dependabot:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add Dependabot labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = ['dependencies', 'semver:patch'];
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels
+            });

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -2,7 +2,7 @@ name: PR Labeler
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened, labeled, synchronize]
 
 permissions:
   contents: read

--- a/.github/workflows/semver-labels.yml
+++ b/.github/workflows/semver-labels.yml
@@ -2,7 +2,7 @@ name: SemVer Labels
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, reopened, labeled, synchronize]
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## Summary

This PR introduces a dedicated GitHub Actions workflow to automatically
label Dependabot pull requests.

Dependabot PRs are intentionally handled outside of `labeler.yml` since
the GitHub labeler only supports file-based rules and cannot reliably
detect bot-originated pull requests.

## What’s included

- New workflow to detect `dependabot[bot]` pull requests
- Automatic labeling with:
  - `dependencies`
  - `semver:patch` (safe default for dependency updates)
- Clean separation between:
  - file-based labeling (`labeler.yml`)
  - bot-based labeling (Dependabot workflow)

## Why this is needed

- Prevents false positives in file-based label rules
- Enables reliable auto-merge rules for Dependabot PRs
- Keeps labeling logic explicit, deterministic, and auditable

## Impact

- No production code changes
- CI / automation only
- No semantic-release version bump triggered

